### PR TITLE
Add a basic code climate config and corresponding badge to the README

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,15 @@
+---
+engines:
+  duplication:
+    enabled: false
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+
+ratings:
+  paths:
+  - "**.rb"
+ 
+exclude_paths:
+ - spec/*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # cg-migration-bot
+[![Code Climate](https://codeclimate.com/github/18F/cg-migration-bot/badges/gpa.svg)](https://codeclimate.com/github/18F/cg-migration-bot)
 
 Monitor CF GovCloud controller users and migrate any associates orgs / spaces / roles.
 


### PR DESCRIPTION
As part of the Fedramp effort, we are required to ensure static code analysis is run on all 18F developed code that is part of the cloud.gov platform:  https://github.com/18F/cg-product/issues/260

In support of this effort, this PR adds a basic code climate configuration and badge to the README.

**Also whomever is reviewing this PR please provide me with access to this repo, so I can configure the webhook required for automatically running code climate on each PR**
